### PR TITLE
Mono on Debian 8

### DIFF
--- a/mono/Dockerfile
+++ b/mono/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:jessie
+
+ENV MONO_VERSION 4.6.2.16
+
+RUN apt-get update \
+  && apt-get install -y curl \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+
+RUN echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-xamarin.list \
+  && echo "deb http://download.mono-project.com/repo/debian wheezy-apache24-compat main" | tee -a /etc/apt/sources.list.d/mono-xamarin.list \
+  && echo "deb http://download.mono-project.com/repo/debian wheezy-libjpeg62-compat main" | tee -a /etc/apt/sources.list.d/mono-xamarin.list \
+  && apt-get update \
+  && apt-get install -y binutils mono-devel ca-certificates-mono fsharp mono-vbnc nuget referenceassemblies-pcl git wget \
+&& rm -rf /var/lib/apt/lists/* /tmp/*


### PR DESCRIPTION
We definitely need a build agent with mono, even for NetCore builds, because dotnet cli does not have "nuget install" functionality yet. But we can not use the standard Mono docker images, because it uses Debian 7, which is not supported by NetCore.