### PR TITLE
New image 1.0.1 Mono 5.0

### DIFF
--- a/mono/1.0.1/Dockerfile
+++ b/mono/1.0.1/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:jessie
+
+# MAINTAINER Jo Shields <jo.shields@xamarin.com>
+# MAINTAINER Alexander Köplinger <alkpli@microsoft.com>
+
+# based on dockerfile by Michael Friis <friism@gmail.com>
+
+ENV MONO_VERSION 5.0.0.100
+
+RUN apt-get update \
+  && apt-get install -y curl \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+
+RUN echo "deb http://download.mono-project.com/repo/debian jessie/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official.list \
+  && apt-get update \
+  && apt-get install -y binutils mono-devel ca-certificates-mono fsharp mono-vbnc nuget referenceassemblies-pcl git wget libunwind8 gettext \
+  && rm -rf /var/lib/apt/lists/* /tmp/*


### PR DESCRIPTION
New version of mono-base using Mono 5.0.  Already uploaded to Docker hub for Akka.NET CI purposes.