### PR TITLE
v1.0.2 image - pushed 062117

### DIFF
--- a/mono/1.0.2/Dockerfile
+++ b/mono/1.0.2/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:jessie-slim
+
+# MAINTAINER Jo Shields <jo.shields@xamarin.com>
+# MAINTAINER Alexander Köplinger <alkpli@microsoft.com>
+
+# based on dockerfile by Michael Friis <friism@gmail.com>
+
+ENV MONO_VERSION 5.0.1.1
+
+RUN apt-get update \
+  && apt-get install -y curl \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+
+RUN echo "deb http://download.mono-project.com/repo/debian jessie/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official.list \
+  && apt-get update \
+  && apt-get install -y binutils mono-devel ca-certificates-mono fsharp mono-vbnc nuget referenceassemblies-pcl \
+# Install .NET CLI dependencies https://raw.githubusercontent.com/dotnet/dotnet-docker/master/1.1/sdk/jessie/Dockerfile
+  && apt-get install -y --no-install-recommends \
+	libc6 \
+	libcurl3 \
+	libgcc1 \
+	libgssapi-krb5-2 \
+	libicu52 \
+	liblttng-ust0 \
+	libssl1.0.0 \
+	libstdc++6 \
+	libunwind8 \
+	libuuid1 \
+	zlib1g \
+  && rm -rf /var/lib/apt/lists/* /tmp/*


### PR DESCRIPTION
Upgrades Mono version to Mono 5.0.1.1 and installs dependencies for .NET CLI according to microsoft dockerfile: https://raw.githubusercontent.com/dotnet/dotnet-docker/master/1.1/sdk/jessie/Dockerfile